### PR TITLE
Enable prebuilding for Node 12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,7 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "9"
     - nodejs_version: "10"
+    - nodejs_version: "12"
 
 platform:
   - x86

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ platform:
   - x64
 
 install:
-  - ps: Install-Product node $env:nodejs_version $env:platform
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version) $env:PLATFORM
   - set PATH=%APPDATA%\npm;%APPVEYOR_BUILD_FOLDER%\node_modules\.bin;%PATH%
   - npm i
 


### PR DESCRIPTION
As part of working towards https://github.com/vweevers/win-detect-browsers/issues/43.

Haven't tested this properly, but it seems pretty clear cut.