### PR TITLE
Don't skip building when cross-installing for win32

### DIFF
--- a/skip.js
+++ b/skip.js
@@ -1,3 +1,4 @@
-if (process.platform === 'win32') {
+const platform = process.env.npm_config_platform || process.platform
+if (platform === 'win32') {
   process.exit(1)
 }


### PR DESCRIPTION
`npm_config_platform=win32` can be used with prebuild-install to download binaries for win32 when running `npm install` on Linux, allowing for cross-platform installs.

This works fine with other similar packages such as [registry-js](https://github.com/desktop/registry-js/), but doesn't work with this package, because `skip.js` assumes that no install step is required at all in this case. This PR ensures that if this env var is set, it overrides the current platform, so on win32 the prebuild step does indeed get run.