### PR TITLE
Fixing the module did not self-register issue when importing in worker threads

### DIFF
--- a/src/VersionInfo.cc
+++ b/src/VersionInfo.cc
@@ -40,4 +40,6 @@ NAN_MODULE_INIT(Init) {
   NAN_EXPORT(target, getInfo);
 }
 
-NODE_MODULE(VersionInfo, Init)
+NODE_MODULE_INIT() {
+  Init(exports);
+}


### PR DESCRIPTION
Importing this package in worker threads (Node 12) causes "Module did not self-register" error, this change fixes that