### PR TITLE
Run tests & prebuild for node 16

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,8 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "10"
     - nodejs_version: "12"
-    - nodejs_version: "14.2.0"
+    - nodejs_version: "14"
+    - nodejs_version: "16"
 
 platform:
   - x86


### PR DESCRIPTION
This PR changes the specific node versions that are tested and prebuilt, to add support for node 16.

This also stops pinning v14 builds to v14.2 (originally pinned in https://github.com/vweevers/win-version-info/pull/16#issuecomment-672986694). That was due to an appveyor issue that seems to now be resolved.

In the medium term I expect that moving to N-API would be good, if that's possible, so none of this is necessary, but in the short term updates like this are quick and easy :smiley:.